### PR TITLE
Update libxmljs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "request": "2.x.x",
     "underscore": "1.x.x",
-    "libxmljs": "0.8.1"
+    "libxmljs": "0.13.0"
   },
   "main": "./api.js",
   "engines": {


### PR DESCRIPTION
0.8.1 was not building for me in the current version of node/node-gyp so I updated my copy to the latest 0.13.0, and it seems to work well.
