### PR TITLE
Add support for KMZ

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,53 +1,81 @@
 var request = require("request"),
-	_ = require("underscore")._,
-	libxmljs = require('libxmljs')
+  _ = require("underscore")._,
+  libxmljs = require('libxmljs'),
+  unzip = require('unzip')
 ;
 
 /*
-	# Simple XML Request
+  # Simple XML Request
 */
-
 exports["parse"] = function(params, credentials, cb) {
-	
-	var reqString = params.url,
-		first = reqString.indexOf('?') === -1 ? true : false;
-	
-	_.each(params, function(val, key) {
-		if(key !== 'url' && key !== 'headers' && key !== 'parseFunction') {
-			reqString += first ? '?' : '&';
-			reqString += key + '=' + val;
-			first = false;
-		}
-	});
-	
-	var handleResponse = function(err, res, xml) {
-		var result, error;
-		if (!err && res.statusCode == 200) {
-			try {
-				var xmlDoc = libxmljs.parseXml(xml);
-				result = params.parseFunction(xmlDoc);
-				error = null;
-			} catch(e) {
-				result = {size: xml.length, error:true, response: xml};
-				error = { msg: "Unable to parse JSON", detail: e.toString() };
-			} finally {
-				cb(error, result );	
-			}
-		} else {
-			try {
-				result = JSON.parse(xml);
-				result.size = xml.length;
-				error = err;
-			} catch(e) {
-				error = err || { statusCode: res.statusCode };
-				error.parseError = e;
-				result = {size: 0, errnum:1, errtxt:"Request failed"}
-			} finally {
-				cb(error, result );	
-			}
-		}
-	}
-	
-	request({url: reqString, headers: params.headers || {}}, handleResponse);
-	
+
+  var reqString = params.url,
+    first = reqString.indexOf('?') === -1 ? true : false;
+
+  _.each(params, function(val, key) {
+    if(key !== 'url' && key !== 'headers' && key !== 'parseFunction') {
+      reqString += first ? '?' : '&';
+      reqString += key + '=' + val;
+      first = false;
+    }
+  });
+
+  var result, error;
+
+  // Parse an XML stream, either a unzipped KML or regular XML response.
+  var parseXml = function(stream) {
+    var xml = '';
+    stream.on('data', function (chunk) {
+      xml += chunk;
+    });
+    stream.on('end', function() {
+      try {
+        var xmlDoc = libxmljs.parseXml(xml);
+        result = params.parseFunction(xmlDoc);
+        error = null;
+      } catch(e) {
+        result = {size: xml.length, error:true, response: xml};
+        error = { msg: "Unable to parse JSON", detail: e.toString() };
+      } finally {
+        cb(error, result );
+      }
+    });
+  }
+
+  var handleResponse = function(res) {
+    if (res.statusCode == 200) {
+      var contentType = res.headers['content-type'];
+      if (contentType.indexOf('.kmz') > -1) {
+        res
+        .pipe(unzip.Parse({verbose: true}))
+        // unzip.Parse emits `entry` event with a Stream
+        .on('entry', parseXml);
+      } else {
+        parseXml(res);
+      }
+    } else {
+      // Non-OK status code
+      var xml = '', err = null;
+      res.on('data', function (chunk) {
+        xml += chunk;
+      });
+      res.on('end', function() {
+        try {
+          result = JSON.parse(xml);
+          result.size = xml.length;
+          error = err;
+        } catch(e) {
+          error = err || { statusCode: res.statusCode };
+          error.parseError = e;
+          result = {size: 0, errnum: 1, errtxt: "Request failed"}
+        } finally {
+          cb( error, result );
+        }
+      });
+    }
+  }
+
+  request({url: reqString, headers: params.headers || {}})
+  .on('error', cb)
+  .on('response', handleResponse)
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "request": "2.x.x",
     "underscore": "1.x.x",
-    "libxmljs": "0.18.7",
+    "libxmljs": "^0.19.5",
     "unzip": "^0.1.11"
   },
   "main": "./api.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "request": "2.x.x",
     "underscore": "1.x.x",
-    "libxmljs": "0.14.2",
+    "libxmljs": "0.18.7",
     "unzip": "^0.1.11"
   },
   "main": "./api.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "request": "2.x.x",
     "underscore": "1.x.x",
-    "libxmljs": "0.14.2"
+    "libxmljs": "0.14.2",
+    "unzip": "^0.1.11"
   },
   "main": "./api.js",
   "engines": {


### PR DESCRIPTION
Google Maps Engine starts returning KMZ instead of KML. This adds
support for unzipping the KMZ before parsing.

Because extraction of the KMZ works on stream, the `res` argument
in `request`'s callback, whose data are already consumed, cannot
be piped to `unzip.Parse`. Therefore, we listen to `response`
event of `request`, which gives us unmodified http.IncomingMessage
object that we can pipe.

This, however, does not give us the response's body, so we have to
do the crazy thing of listen to `data` and `end` events.

Other changes are just white spaces.
